### PR TITLE
Dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,9 @@ RUN node_modules/bower/bin/bower install --allow-root
 
 RUN nosetests --all-modules --exe
 
+RUN python3 run.py --freeze
+
 EXPOSE 5050
 
 ENTRYPOINT ["python3"]
-CMD ["run.py" ,"--host", "0.0.0.0", "--freeze"]
+CMD ["run.py" ,"--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN node_modules/bower/bin/bower install --allow-root
 
 RUN nosetests --all-modules --exe
 
-RUN python3 run.py --freeze
+RUN python3 run.py --freeze --norun
 
 EXPOSE 5050
 

--- a/run.py
+++ b/run.py
@@ -9,10 +9,12 @@ if __name__ == '__main__':
     parser.add_argument('--host', '-ht', type=str)
     parser.add_argument('--port', '-p', type=str)
     parser.add_argument('--freeze', '-f', action='store_true', default=False)
+    parser.add_argument('--norun', '-n', action='store_true', default=False)
     args = parser.parse_args()
     host_val = args.host
     port_val = args.port
     do_freeze = args.freeze
+    no_run = args.norun
 
     if host_val is not None:
         host = host_val
@@ -28,7 +30,8 @@ if __name__ == '__main__':
         print("freezing")
         freezer.freeze()
         print("frozen")
-        freezer.serve(host=host, port=port, threaded=True)
+        if not no_run:
+            freezer.serve(host=host, port=port, threaded=True)
     else:
         application.run(host=host, port=port, threaded=True)
     # run from the command line as follows


### PR DESCRIPTION
The Dockerfile and run.py have been updated so that the application now freezes on build. A --norun flag was added to run.py so that the application can be frozen without being run.

A MimetypeMismatchWarning persists from the merge where the json data was returned from a view.