### PR TITLE
Remove de-empahsis interaction from map

### DIFF
--- a/floodviz/static/css/map.css
+++ b/floodviz/static/css/map.css
@@ -5,25 +5,11 @@
 	opacity: .9;
 }
 
-#map circle.gage-point-bland {
-	stroke: #004500;
-	stroke-width: 2;
-	fill-opacity: 0;
-	opacity: .5;
-}
-
 #map circle.gage-point-accent {
 stroke: #00d040 ;
 stroke-width: 3;
 fill-opacity: 0;
 opacity: 1;
-}
-
-#map circle.gage-point-accent-bland{
-stroke: #00d040 ;
-stroke-width: 3;
-fill-opacity: 0;
-opacity: 0.5;
 }
 
 #map circle.ref-point{

--- a/floodviz/static/js/hydrograph.js
+++ b/floodviz/static/js/hydrograph.js
@@ -69,11 +69,13 @@
 		 * @param exemptkey - The key of the one line that should not be de-emphasized
 		 */
 		var make_lines_bland = function (exemptkey){
-			FV.hydrograph_display_ids.forEach(function(id) {
-				if(id !== exemptkey){
-					d3.select('#hydro' + id).attr('class', 'hydro-inactive-bland');
-				}
-			})
+			if(FV.hydrograph_display_ids.indexOf(exemptkey) !== -1) {
+				FV.hydrograph_display_ids.forEach(function (id) {
+					if (id !== exemptkey) {
+						d3.select('#hydro' + id).attr('class', 'hydro-inactive-bland');
+					}
+				})
+			}
 		};
 
 

--- a/floodviz/static/js/map.js
+++ b/floodviz/static/js/map.js
@@ -236,38 +236,6 @@
 			};
 
 			/**
-			 * De-emphasize all sites except the one specified
-			 * @param exemptkey - The key of the one site that should not be de-emphasized
-			 */
-			var make_sites_bland = function (exemptkey) {
-				Object.keys(state.gages).forEach(function (key) {
-					const g = state.gages[key];
-					var style = 'gage-point';
-					if (g.accent) {
-						style += '-accent'
-					}
-					if (key !== exemptkey) {
-						style += '-bland';
-					}
-					d3.select('#map' + key).attr('class', style);
-				});
-			};
-
-			/**
-			 * reset all sites to normal styling (not bland)
-			 */
-			var make_sites_normal = function () {
-				Object.keys(state.gages).forEach(function (key) {
-					const g = state.gages[key];
-					var style = 'gage-point';
-					if (g.accent) {
-						style += '-accent'
-					}
-					d3.select('#map' + key).attr('class', style);
-				});
-			};
-
-			/**
 			 * Initialize the Map.
 			 *
 			 *@param {Object} linked_interactions - Object holding functions that link to another figure's interactions.
@@ -361,7 +329,6 @@
 			 * Shows sitename tooltip on map figure at correct location.
 			 */
 			self.site_tooltip_show = function (sitename, sitekey) {
-				make_sites_bland(sitekey);
 				var gage_point_cords = document.getElementById('map' + sitekey).getBoundingClientRect();
 				maptip.transition().duration(500);
 				maptip.style('display', 'inline-block')
@@ -373,7 +340,6 @@
 			 * Removes tooltip style from map site.
 			 */
 			self.site_tooltip_remove = function () {
-				make_sites_normal();
 				maptip.style('display', 'none');
 			};
 


### PR DESCRIPTION
Also, change `hydrograph.js` so that when the user mouses over a gage on the map that is not displayed on the hydrograph, no lines are de-emphasized. Previously, all lines were de-emphasized.
